### PR TITLE
Add the parameter 'timeout' to change the timeout of the underlying exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Specifies that when installing the windows feature it should perform and restart
 #####`source`
 Speficies the location of the feature files. This may be a network location or a path to the specific wim file.
 
+#####`timeout`
+Specifies the timeout in seconds (default is 300) after which the module will conclude the configuration has failed and abort.
+
 ##Reference
 
 


### PR DESCRIPTION
This solves an issue when installing lots of features on slow machines, where the exec terminated the command after its default 300 seconds, even though the installation was (slowly) progressing. This has the potential of leaving the target system in a rather broken state if the machine is slow and/or is using its cycles for other work and the installation is killed halfway through.