### PR TITLE
Add a timeout param for long installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ Provides the name of the feature that you want to install if this differs from t
 Specifies that all applicable management tools should be installed for the given feature. Defaults to `false`
 
 #####`installsubfeatures`
-Specifiies that all subordinate features of this feature are also installed. Defaults to `false`
+Specifies that all subordinate features of this feature are also installed. Defaults to `false`
 
 #####`restart`
 Specifies that when installing the windows feature it should perform and restart automatically.
 
 #####`source`
-Speficies the location of the feature files. This may be a network location or a path to the specific wim file.
+Specifies the location of the feature files. This may be a network location or a path to the specific wim file.
+
+#####`timeout`
+Specifies the timeout in seconds for the feature installation. Use this if the feature takes longer than 300 seconds to complete.
 
 ##Reference
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,8 @@ define windowsfeature (
     $installmanagementtools = false,
     $installsubfeatures = false,
     $restart = false,
-    $source = false
+    $source = false,
+    $timeout = 300,
 ) {
 
   validate_re($ensure, '^(present|absent)$', 'valid values for ensure are \'present\' or \'absent\'')
@@ -105,13 +106,15 @@ define windowsfeature (
     exec { "add-feature-${title}":
       command  => "Import-Module ServerManager; ${command} ${features} ${_installmanagementtools} ${_installsubfeatures} ${_installsource} -Restart:$${_restart}",
       onlyif   => "Import-Module ServerManager; if (@(Get-WindowsFeature ${features} | ?{\$_.Installed -match \'false\'}).count -eq 0) { exit 1 }",
-      provider => powershell
+      provider => powershell,
+      timeout  => $timeout,
     }
   } elsif ($ensure == 'absent') {
     exec { "remove-feature-${title}":
       command  => "Import-Module ServerManager; Remove-WindowsFeature ${features} -Restart:$${_restart}",
       onlyif   => "Import-Module ServerManager; if (@(Get-WindowsFeature ${features} | ?{\$_.Installed -match \'true\'}).count -eq 0) { exit 1 }",
-      provider => powershell
+      provider => powershell,
+      timeout  => $timeout,
     }
   }
 }


### PR DESCRIPTION
Some things (like IIS) can take a very long time to complete
installation. This allows the user to specify a timeout for the exec, so
that the Puppet run doesn't fail.